### PR TITLE
Wait for container to report as running (#2)

### DIFF
--- a/examples/notes-service/record.sh
+++ b/examples/notes-service/record.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
-(cd ../../cli && go build)
+(cd ../.. && go build)
 (cd ./tests && npm install)
 
-../../cli/docker-test record \
+../../docker-test record \
     --service notes-service \
     --compose ./docker-compose.yml \
-    --sleep 30 \
+    --sleep 3000 \
     --test 'cd ./tests && npm test'
 

--- a/examples/notes-service/replay.sh
+++ b/examples/notes-service/replay.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-(cd ../../cli && go build)
+(cd ../.. && go build)
 
-../../cli/docker-test replay \
+../../docker-test replay \
     --service notes-service \
     --compose ./docker-compose.yml \
-    --sleep 10 \
+    --sleep 3000 \
     --test 'cd ./tests && npm test'
 


### PR DESCRIPTION
We still need to wait longer until the service is ready to be tested.