### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+go:
+  - 1.11.x
+node_js:
+  - 7
+services:
+  - docker
+
+install:
+  - (cd examples/notes-service && make)
+
+script:
+  - (cd examples/notes-service && ./record.sh)
+  - (cd examples/notes-service && ./replay.sh)
+
+cache:
+  npm: true

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+all: install
+
+install:
+	GO111MODULE=on go build

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://user-images.githubusercontent.com/7422050/56345043-1924ca00-61bf-11e9-9832-58a50379851f.png" width="200" alt="Looper"/>
 </p>
 
-## Usage
+## Usage [![Build Status](https://travis-ci.com/fawind/docker-test.svg?token=RTEhNHKreGSnaC3U1jh2&branch=master)](https://travis-ci.com/fawind/docker-test)
 
 ```
 >> docker-test --help

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -23,6 +23,7 @@ services:
     volumes:
       - ./dump:/dump
   {{.Service}}:
+    container_name: {{.Service}}
     depends_on:
       - mitm-proxy
     environment:

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -23,7 +23,6 @@ services:
     volumes:
       - ./dump:/dump
   {{.Service}}:
-    container_name: service
     depends_on:
       - mitm-proxy
     environment:

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -57,10 +57,10 @@ func Execute() {
 
 func runRecord(service string, testCmd string, port int, outFile string, serviceCompose string, dockerSleep int) {
 	proxyComposeContent := GetRecordCompose(service, port, outFile)
-	ExecTest(serviceCompose, proxyComposeContent, testCmd, time.Duration(dockerSleep)*time.Millisecond, []string{})
+	ExecTest(service, serviceCompose, proxyComposeContent, testCmd, time.Duration(dockerSleep)*time.Millisecond, []string{})
 }
 
 func runReplay(service string, testCmd string, port int, outFile string, serviceCompose string, dockerSleep int) {
 	proxyComposeContent := GetReplayCompose(service, port, outFile)
-	ExecTest(serviceCompose, proxyComposeContent, testCmd, time.Duration(dockerSleep)*time.Millisecond, []string{service, MITMProxy})
+	ExecTest(service, serviceCompose, proxyComposeContent, testCmd, time.Duration(dockerSleep)*time.Millisecond, []string{service, MITMProxy})
 }

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-const defaultRetries = 600 // 10 minutes
+const maxDockerRetries = 600 // 10 minutes
 
 // ExecTest starts the docker images and executes the tests
 func ExecTest(service string, serviceCompose string, proxyComposeContent string, testCmdInput string, dockerSleep time.Duration, servicesToStart []string) {
@@ -40,9 +40,9 @@ func ExecTest(service string, serviceCompose string, proxyComposeContent string,
 
 // waitForService waits for the docker container under test to report as running
 func waitForService(serviceName string) {
-	retries := defaultRetries
+	retries := maxDockerRetries
 	log.Println("Waiting for docker services to be started")
-	for executeCheckRunningCmd(serviceName, retries) && retries > 0 {
+	for !executeCheckRunningCmd(serviceName, retries) && retries > 0 {
 		retries--
 		time.Sleep(1 * time.Second)
 	}
@@ -54,7 +54,6 @@ func waitForService(serviceName string) {
 
 func executeCheckRunningCmd(serviceName string, retries int) bool {
 	cmd := exec.Command("sh", "-c", "docker inspect -f {{.State.Running}} "+serviceName)
-	cmd.Stderr = os.Stderr
 	out, err := cmd.Output()
 	if err != nil {
 		return false

--- a/cmd/testrunner.go
+++ b/cmd/testrunner.go
@@ -12,13 +12,15 @@ import (
 	"github.com/pkg/errors"
 )
 
+const defaultRetries = 600 // 10 minutes
+
 // ExecTest starts the docker images and executes the tests
-func ExecTest(serviceCompose string, proxyComposeContent string, testCmdInput string, dockerSleep time.Duration, servicesToStart []string) {
+func ExecTest(service string, serviceCompose string, proxyComposeContent string, testCmdInput string, dockerSleep time.Duration, servicesToStart []string) {
 	proxyFile := createTmpFile(proxyComposeContent)
 	defer os.Remove(proxyFile.Name())
 	dockerCmd := startDocker(serviceCompose, proxyFile.Name(), servicesToStart)
 
-	waitForService()
+	waitForService(service)
 
 	if dockerSleep.Nanoseconds() > 0 {
 		log.Println("Sleep before executing tests")
@@ -37,23 +39,29 @@ func ExecTest(serviceCompose string, proxyComposeContent string, testCmdInput st
 }
 
 // waitForService waits for the docker container under test to report as running
-func waitForService() {
+func waitForService(serviceName string) {
+	retries := defaultRetries
 	log.Println("Waiting for docker services to be started")
-	for executeCheckRunningCmd() {
+	for executeCheckRunningCmd(serviceName, retries) && retries > 0 {
+		retries--
 		time.Sleep(1 * time.Second)
+	}
+	if retries == 0 {
+		log.Fatal("Error waiting for docker services, timeout reached")
 	}
 	log.Println("Docker services reported as running")
 }
 
-func executeCheckRunningCmd() bool {
-	cmd := exec.Command("sh", "-c", "docker inspect -f {{.State.Running}} service")
-	out, err := cmd.CombinedOutput()
+func executeCheckRunningCmd(serviceName string, retries int) bool {
+	cmd := exec.Command("sh", "-c", "docker inspect -f {{.State.Running}} "+serviceName)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "Error executing docker inspect command"))
+		return false
 	}
 	isRunning, err := strconv.ParseBool(strings.TrimSuffix(string(out), "\n"))
 	if err != nil {
-		log.Fatal(errors.Wrap(err, "Error parsing docker inspect output"))
+		return false
 	}
 	return isRunning
 }

--- a/examples/notes-service/Makefile
+++ b/examples/notes-service/Makefile
@@ -1,0 +1,4 @@
+all: install
+
+install:
+	(cd ./tests && npm install) && docker-compose build

--- a/examples/notes-service/record.sh
+++ b/examples/notes-service/record.sh
@@ -6,6 +6,6 @@ set -e
 ../../docker-test record \
     --service notes-service \
     --compose ./docker-compose.yml \
-    --sleep 10000 \
+    --sleep 2000 \
     --test 'cd ./tests && npm test'
 

--- a/examples/notes-service/record.sh
+++ b/examples/notes-service/record.sh
@@ -6,6 +6,5 @@ set -e
 ../../docker-test record \
     --service notes-service \
     --compose ./docker-compose.yml \
-    --sleep 2000 \
     --test 'cd ./tests && npm test'
 

--- a/examples/notes-service/record.sh
+++ b/examples/notes-service/record.sh
@@ -1,12 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-(cd ../.. && go build)
-(cd ./tests && npm install)
+(cd ../.. && make)
 
 ../../docker-test record \
     --service notes-service \
     --compose ./docker-compose.yml \
-    --sleep 3000 \
+    --sleep 10000 \
     --test 'cd ./tests && npm test'
 

--- a/examples/notes-service/replay.sh
+++ b/examples/notes-service/replay.sh
@@ -6,6 +6,5 @@ set -e
 ../../docker-test replay \
     --service notes-service \
     --compose ./docker-compose.yml \
-    --sleep 2000 \
     --test 'cd ./tests && npm test'
 

--- a/examples/notes-service/replay.sh
+++ b/examples/notes-service/replay.sh
@@ -6,6 +6,6 @@ set -e
 ../../docker-test replay \
     --service notes-service \
     --compose ./docker-compose.yml \
-    --sleep 10000 \
+    --sleep 2000 \
     --test 'cd ./tests && npm test'
 

--- a/examples/notes-service/replay.sh
+++ b/examples/notes-service/replay.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-(cd ../.. && go build)
+(cd ../.. && make)
 
 ../../docker-test replay \
     --service notes-service \
     --compose ./docker-compose.yml \
-    --sleep 3000 \
+    --sleep 10000 \
     --test 'cd ./tests && npm test'
 


### PR DESCRIPTION
* Integrate Travis, testing the tool using the `notes-service` stack ([travis-ci.com/fawind/docker-test](https://travis-ci.com/fawind/docker-test)).
* Adds timeout when waiting for docker services to start.
* Waiting for a docker container is now done using the actual service name instead of the alias `service`.