### PR TITLE
Name replay dumps based on tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
 
 script:
   - (cd examples/notes-service && ./record.sh)
+  - sleep 1
   - (cd examples/notes-service && ./replay.sh)
 
 cache:

--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -11,17 +11,18 @@ type composeOptions struct {
 	MitmArg string
 	OutFile string
 	Port    int
+	DumpDir string
 }
 
 const composeTemplate string = `version: '3'
 services:
   mitm-proxy:
     image: mitmproxy/mitmproxy
-    entrypoint: "mitmdump {{.MitmArg}} /dump/{{.OutFile}} -p {{.Port}}"
+    entrypoint: "mitmdump {{.MitmArg}} /{{.DumpDir}}/{{.OutFile}} -p {{.Port}}"
     ports:
       - "{{.Port}}:{{.Port}}"
     volumes:
-      - ./dump:/dump
+      - ./{{.DumpDir}}:/{{.DumpDir}}
   {{.Service}}:
     container_name: {{.Service}}
     depends_on:
@@ -31,17 +32,17 @@ services:
 `
 
 // GetRecordCompose returns the docker-compose config for record mode
-func GetRecordCompose(service string, port int, outFile string) string {
-	return getCompose(true, service, port, outFile)
+func GetRecordCompose(service string, port int, outFile string, dumpDir string) string {
+	return getCompose(true, service, port, outFile, dumpDir)
 }
 
 // GetReplayCompose returns the docker-compose config for replaying mode
-func GetReplayCompose(service string, port int, outFile string) string {
-	return getCompose(false, service, port, outFile)
+func GetReplayCompose(service string, port int, outFile string, dumpDir string) string {
+	return getCompose(false, service, port, outFile, dumpDir)
 }
 
-func getCompose(isRecord bool, service string, port int, outFile string) string {
-	var tmplOptions = composeOptions{service, getMitmArgs(isRecord), outFile, port}
+func getCompose(isRecord bool, service string, port int, outFile string, dumpDir string) string {
+	var tmplOptions = composeOptions{service, getMitmArgs(isRecord), outFile, port, dumpDir}
 	var tmpl, err = template.New("MITM Docker Compose").Parse(composeTemplate)
 	if err != nil {
 		panic(errors.Wrap(err, "Error parsing template"))

--- a/cmd/dumpfiles.go
+++ b/cmd/dumpfiles.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path"
+)
+
+// GetDumpFileName returns the default filename for a test dump file
+func GetDumpFileName(service string, testCmd string) string {
+	return fmt.Sprint(service, "-", getFingerprint(testCmd), ".mitmdump")
+}
+
+// DumpExists checks if the dump file exists
+func DumpExists(dumpDir string, outFile string) bool {
+	_, err := os.Stat(path.Join(dumpDir, outFile))
+	return !os.IsNotExist(err)
+}
+
+func getFingerprint(testCmd string) string {
+	hash := sha1.New()
+	hash.Write([]byte(testCmd))
+	return hex.EncodeToString(hash.Sum(nil))
+}

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -2,35 +2,42 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+	"log"
 	"time"
 )
 
 // MITMProxy holds the name of the docker-service for recording requests
 const MITMProxy = "mitm-proxy"
 
+// Config contains the config parameters
+type Config struct {
+	service        string
+	testCmd        string
+	port           int
+	outFile        string
+	dumpDir        string
+	serviceCompose string
+	dockerSleep    int
+}
+
 // Execute executes the root command for the CLI app
 func Execute() {
-	var (
-		service        string
-		testCmd        string
-		port           int
-		outFile        string
-		serviceCompose string
-		dockerSleep    int
-	)
+	var cfg Config
 	var rootCmd = &cobra.Command{Use: "app"}
 	var cmdRecord = &cobra.Command{
 		Use:   "record",
 		Short: "Run in record mode",
 		Run: func(cmd *cobra.Command, args []string) {
-			runRecord(service, testCmd, port, outFile, serviceCompose, dockerSleep)
+			cfg.outFile = getDumpFile(cfg.outFile, cfg.service, cfg.testCmd)
+			runRecord(cfg)
 		},
 	}
 	var cmdReplay = &cobra.Command{
 		Use:   "replay",
 		Short: "Run in replay mode",
 		Run: func(cmd *cobra.Command, args []string) {
-			runReplay(service, testCmd, port, outFile, serviceCompose, dockerSleep)
+			cfg.outFile = getDumpFile(cfg.outFile, cfg.service, cfg.testCmd)
+			runReplay(cfg)
 		},
 	}
 
@@ -38,29 +45,56 @@ func Execute() {
 	rootCmd.AddCommand(cmdReplay)
 
 	rootCmd.PersistentFlags().StringVar(
-		&service, "service", "", "Docker service name to test (required)")
+		&cfg.service, "service", "", "Docker service name to test (required)")
 	rootCmd.PersistentFlags().StringVar(
-		&testCmd, "test", "", "Test command to execute (required)")
+		&cfg.testCmd, "test", "", "Test command to execute (required)")
 	rootCmd.PersistentFlags().IntVar(
-		&port, "port", 9999, "Port to use for the MITM proxy")
+		&cfg.port, "port", 9999, "Port to use for the MITM proxy")
 	rootCmd.PersistentFlags().StringVar(
-		&outFile, "out", "out.mitmdump", "File name for the mitm output file")
+		&cfg.serviceCompose, "compose", "./docker-compose.yml", "Default docker-compose file for the services")
 	rootCmd.PersistentFlags().StringVar(
-		&serviceCompose, "compose", "./docker-compose.yml", "Default docker-compose file for the services")
+		&cfg.outFile, "out", "", "File name for the mitm output file")
+	rootCmd.PersistentFlags().StringVar(
+		&cfg.dumpDir, "directory", "replay-dumps", "Directory to store the test dumps in")
 	rootCmd.PersistentFlags().IntVar(
-		&dockerSleep, "sleep", 0, "Time to wait after starting docker services in ms")
+		&cfg.dockerSleep, "sleep", 0, "Time to wait after starting docker services in ms")
+
 	rootCmd.MarkPersistentFlagRequired("service")
 	rootCmd.MarkPersistentFlagRequired("test")
 
 	rootCmd.Execute()
 }
 
-func runRecord(service string, testCmd string, port int, outFile string, serviceCompose string, dockerSleep int) {
-	proxyComposeContent := GetRecordCompose(service, port, outFile)
-	ExecTest(service, serviceCompose, proxyComposeContent, testCmd, time.Duration(dockerSleep)*time.Millisecond, []string{})
+func runRecord(cfg Config) {
+	proxyComposeContent := GetRecordCompose(cfg.service, cfg.port, cfg.outFile, cfg.dumpDir)
+	ExecTest(
+		cfg.service,
+		cfg.serviceCompose,
+		proxyComposeContent,
+		cfg.testCmd,
+		time.Duration(cfg.dockerSleep)*time.Millisecond,
+		[]string{})
+	log.Printf("Request log saved to \"%s/%s\"", cfg.dumpDir, cfg.outFile)
 }
 
-func runReplay(service string, testCmd string, port int, outFile string, serviceCompose string, dockerSleep int) {
-	proxyComposeContent := GetReplayCompose(service, port, outFile)
-	ExecTest(service, serviceCompose, proxyComposeContent, testCmd, time.Duration(dockerSleep)*time.Millisecond, []string{service, MITMProxy})
+func runReplay(cfg Config) {
+	log.Printf("Request log saved to \"%s/%s\"", cfg.dumpDir, cfg.outFile)
+	if !DumpExists(cfg.dumpDir, cfg.outFile) {
+		log.Fatal("Dump file not found. Run record first or manually provide a dump file.")
+	}
+	proxyComposeContent := GetReplayCompose(cfg.service, cfg.port, cfg.outFile, cfg.dumpDir)
+	ExecTest(
+		cfg.service,
+		cfg.serviceCompose,
+		proxyComposeContent,
+		cfg.testCmd,
+		time.Duration(cfg.dockerSleep)*time.Millisecond,
+		[]string{cfg.service, MITMProxy})
+}
+
+func getDumpFile(outFile string, service string, testCmd string) string {
+	if len(outFile) > 0 {
+		return outFile
+	}
+	return GetDumpFileName(service, testCmd)
 }


### PR DESCRIPTION
* Closes #7.
* Per default, the request dump files are named based on the service name to test and the sha1 hash of the provided test command. E.g. `notes-service-c4abb0[...].mitmdump`.
* Can still be overridden using the `--out` flag.