### PR TITLE
Add standalone proxy use

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 ```
 >> docker-test --help
+
 Usage:
   app [command]
 
@@ -15,16 +16,19 @@ Available Commands:
   replay      Run in replay mode
 
 Flags:
-      --compose string   docker-compose file for the services (default "./docker-compose.yml")
-  -h, --help             help for app
-      --out string       File name for the mitm output file (default "out.mitmdump")
-      --port int         Port to use for the MITM proxy (default 9999)
-      --service string   Docker service name to test (required)
-      --sleep int        Time to wait after starting docker services in ms (optional)
-      --test string      Test command to execute (required)
+      --compose string     Default docker-compose file for the services (default "./docker-compose.yml")
+      --directory string   Directory to store the test dumps in (default "replay-dumps")
+  -h, --help               help for app
+      --out string         File name for the mitm output file (required when run in stand-alone proxy mode)
+      --port int           Port to use for the MITM proxy (default 9999)
+      --proxyOnly          Only start proxy in stand-alone mode
+      --service string     Docker setService name to test (required when not run in stand-alone proxy mode)
+      --sleep int          Time to wait after starting docker services in ms
+      --test string        Test command to execute (required when not run in stand-alone proxy mode)
 ```
 
-1. Install or build the project:
+### Install or build the project:
+
 ```bash
 # Build
 go build
@@ -32,7 +36,9 @@ go build
 go get github.com/fawind/docker-test
 ```
 
-2. Run service in record mode:
+### Test docker-compose services
+
+1. Run service in record mode:
 ```bash
 docker-test record \
     --service my-service \
@@ -40,13 +46,31 @@ docker-test record \
     --test '<TESTCMD>'
 ```
 
-3. Run service in replay mode:
+2. Run service in replay mode:
 ```bash
 docker-test replay \
     --service my-service \
     --compose ./path/to/docker-compose.yml \
     --test '<TESTCMD>'
 ```
+
+### Run proxy in stand-alone mode
+
+1. Run proxy in record mode:
+```bash
+docker-test record \
+    --proxyOnly \
+    --out my-dump.mitmdump
+```
+2. Set up a proxy of your service-under-test. E.g. using `export http_proxy='http://0.0.0.0:9999'`.
+3. Run your tests. Afterwards you have to manually close the proxy using `Ctrl-C`.
+4. Run proxy in replay mode:
+```bash
+docker-test replay \
+    --proxyOnly \
+    --out my-dump.mitmdump
+```
+5. Run your tests again. This time all responses will be replayed.
 
 ### Example Application
 

--- a/cmd/rootCmd.go
+++ b/cmd/rootCmd.go
@@ -1,16 +1,25 @@
 package cmd
 
 import (
+	"fmt"
 	"github.com/spf13/cobra"
 	"log"
+	"os"
+	"strings"
 	"time"
 )
+
+// Required flag names
+const serviceFlag = "service"
+const testCmdFlag = "test"
+const outFileFlag = "out"
 
 // MITMProxy holds the name of the docker-service for recording requests
 const MITMProxy = "mitm-proxy"
 
-// Config contains the config parameters
+// Config contains the config parameters for record and replay modes
 type Config struct {
+	proxyOnly      bool
 	service        string
 	testCmd        string
 	port           int
@@ -28,6 +37,7 @@ func Execute() {
 		Use:   "record",
 		Short: "Run in record mode",
 		Run: func(cmd *cobra.Command, args []string) {
+			verifyFlags(cfg, cmd)
 			cfg.outFile = getDumpFile(cfg.outFile, cfg.service, cfg.testCmd)
 			runRecord(cfg)
 		},
@@ -36,45 +46,49 @@ func Execute() {
 		Use:   "replay",
 		Short: "Run in replay mode",
 		Run: func(cmd *cobra.Command, args []string) {
+			verifyFlags(cfg, cmd)
 			cfg.outFile = getDumpFile(cfg.outFile, cfg.service, cfg.testCmd)
 			runReplay(cfg)
 		},
 	}
 
-	rootCmd.AddCommand(cmdRecord)
-	rootCmd.AddCommand(cmdReplay)
-
+	// Flags for record and replay mode
+	rootCmd.PersistentFlags().BoolVar(
+		&cfg.proxyOnly, "proxyOnly", false, "Only start proxy in stand-alone mode")
 	rootCmd.PersistentFlags().StringVar(
-		&cfg.service, "service", "", "Docker service name to test (required)")
+		&cfg.service, serviceFlag, "", "Docker setService name to test (required when not run in stand-alone proxy mode)")
 	rootCmd.PersistentFlags().StringVar(
-		&cfg.testCmd, "test", "", "Test command to execute (required)")
+		&cfg.testCmd, testCmdFlag, "", "Test command to execute (required when not run in stand-alone proxy mode)")
 	rootCmd.PersistentFlags().IntVar(
 		&cfg.port, "port", 9999, "Port to use for the MITM proxy")
 	rootCmd.PersistentFlags().StringVar(
 		&cfg.serviceCompose, "compose", "./docker-compose.yml", "Default docker-compose file for the services")
 	rootCmd.PersistentFlags().StringVar(
-		&cfg.outFile, "out", "", "File name for the mitm output file")
+		&cfg.outFile, outFileFlag, "", "File name for the mitm output file (required when run in stand-alone proxy mode)")
 	rootCmd.PersistentFlags().StringVar(
 		&cfg.dumpDir, "directory", "replay-dumps", "Directory to store the test dumps in")
 	rootCmd.PersistentFlags().IntVar(
 		&cfg.dockerSleep, "sleep", 0, "Time to wait after starting docker services in ms")
 
-	rootCmd.MarkPersistentFlagRequired("service")
-	rootCmd.MarkPersistentFlagRequired("test")
-
+	rootCmd.AddCommand(cmdRecord, cmdReplay)
 	rootCmd.Execute()
 }
 
 func runRecord(cfg Config) {
-	proxyComposeContent := GetRecordCompose(cfg.service, cfg.port, cfg.outFile, cfg.dumpDir)
-	ExecTest(
-		cfg.service,
-		cfg.serviceCompose,
-		proxyComposeContent,
-		cfg.testCmd,
-		time.Duration(cfg.dockerSleep)*time.Millisecond,
-		[]string{})
 	log.Printf("Request log saved to \"%s/%s\"", cfg.dumpDir, cfg.outFile)
+	proxyComposeContent := getComposeForCfg(true, cfg)
+	if cfg.proxyOnly {
+		log.Printf("Starting stand-alone proxy mode. Use Ctrl-c to close")
+		ExecProxy(proxyComposeContent)
+	} else {
+		ExecTest(
+			cfg.service,
+			cfg.serviceCompose,
+			proxyComposeContent,
+			cfg.testCmd,
+			time.Duration(cfg.dockerSleep)*time.Millisecond,
+			[]string{})
+	}
 }
 
 func runReplay(cfg Config) {
@@ -82,14 +96,66 @@ func runReplay(cfg Config) {
 	if !DumpExists(cfg.dumpDir, cfg.outFile) {
 		log.Fatal("Dump file not found. Run record first or manually provide a dump file.")
 	}
-	proxyComposeContent := GetReplayCompose(cfg.service, cfg.port, cfg.outFile, cfg.dumpDir)
-	ExecTest(
-		cfg.service,
-		cfg.serviceCompose,
-		proxyComposeContent,
-		cfg.testCmd,
-		time.Duration(cfg.dockerSleep)*time.Millisecond,
-		[]string{cfg.service, MITMProxy})
+	proxyComposeContent := getComposeForCfg(false, cfg)
+	if cfg.proxyOnly {
+		log.Printf("Starting stand-alone proxy mode. Use Ctrl-c to close")
+		ExecProxy(proxyComposeContent)
+	} else {
+		ExecTest(
+			cfg.service,
+			cfg.serviceCompose,
+			proxyComposeContent,
+			cfg.testCmd,
+			time.Duration(cfg.dockerSleep)*time.Millisecond,
+			[]string{cfg.service, MITMProxy})
+	}
+}
+
+func getComposeForCfg(isRecord bool, cfg Config) string {
+	var recordOption RecordOption
+	if isRecord {
+		recordOption = SetRecord()
+	} else {
+		recordOption = SetReplay()
+	}
+	var modeOption ModeOption
+	if cfg.proxyOnly {
+		modeOption = SetProxyMode()
+	} else {
+		modeOption = SetDockerMode(cfg.service)
+	}
+	return GetCompose(recordOption, modeOption, cfg.port, cfg.outFile, cfg.dumpDir)
+}
+
+func verifyFlags(cfg Config, cmd *cobra.Command) {
+	errorMsg := "Error: Flag(s) %s not set "
+	hasError := false
+	var missingFlags []string
+	var errorSuffix string
+	if !cfg.proxyOnly {
+		if len(cfg.service) == 0 {
+			missingFlags = append(missingFlags, "--"+serviceFlag)
+			hasError = true
+		}
+		if len(cfg.testCmd) == 0 {
+			missingFlags = append(missingFlags, "--"+testCmdFlag)
+			hasError = true
+		}
+		if hasError {
+			errorSuffix = "which are required when not run in stand-alone proxy mode\n"
+		}
+	} else {
+		if len(cfg.outFile) == 0 {
+			missingFlags = append(missingFlags, "--"+outFileFlag)
+			errorSuffix = "which are required when run in stand-alone proxy mode\n"
+			hasError = true
+		}
+	}
+	if hasError {
+		fmt.Printf(errorMsg+errorSuffix, strings.Join(missingFlags, ", "))
+		cmd.Help()
+		os.Exit(0)
+	}
 }
 
 func getDumpFile(outFile string, service string, testCmd string) string {


### PR DESCRIPTION
Closes #12.

Usage:
```bash
# Record
docker-test record \
    --proxyOnly \
    --out my-dump.mitmdump

# Replay
docker-test replay \
    --proxyOnly \
    --out my-dump.mitmdump
```

The client has to set up the proxy them self (e.g.: `export http_proxy='http://0.0.0.0:9999'; curl my-service:5000/test`).
